### PR TITLE
Allow configuration of the kyoto stuff via pkg-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: c++
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libtokyocabinet-dev libkyototycoon-dev kyototycoon libkyotocabinet-dev libhiredis-dev; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install tokyo-cabinet kyoto-cabinet kyoto-tycoon; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew upgrade; brew install xz tokyo-cabinet kyoto-cabinet kyoto-tycoon; fi
 script:
   - make && PATH=$PATH:`pwd`/bin make test
 os:

--- a/include.mk
+++ b/include.mk
@@ -71,6 +71,7 @@ else
 endif
 # location of Tokyo cabinet
 ifndef tokyoCabinetLib
+HAVE_KYOTO_CABINET = $(shell pkg-config --exists kyotocabinet; echo $$?)
 ifneq ($(wildcard /hive/groups/recon/local/include/tcbdb.h),)
    # hgwdev hive install
    tcPrefix = /hive/groups/recon/local
@@ -91,11 +92,16 @@ else ifneq ($(wildcard /usr/include/tcbdb.h),)
    tcPrefix = /usr
    tokyoCabinetIncl = -I${tcPrefix}/include -DHAVE_TOKYO_CABINET=1
    tokyoCabinetLib = -L${tcPrefix}/lib -Wl,-rpath,${tcPrefix}/lib -ltokyocabinet -lz -lbz2 -lpthread -lm
+else ifeq (${HAVE_KYOTO_TYCOON},0)
+   # Install registered with pkg-config
+   tokyoCabinetIncl = $(shell pkg-config --cflags kyotocabinet) -DHAVE_KYOTO_CABINET=1
+   tokyoCabinetLib = $(shell pkg-config --libs-only-L kyotocabinet) -Wl,-rpath,$(shell pkg-config --variable=libdir kyotocabinet) $(shell pkg-config --libs-only-l --static kyotocabinet)
 endif
 endif
 
 # location of Kyoto Tycoon
 ifndef kyotoTycoonLib
+HAVE_KYOTO_TYCOON = $(shell pkg-config --exists kyototycoon; echo $$?)
 ifneq ($(wildcard /hive/groups/recon/local/include/ktcommon.h),)
    # hgwdev hive install
    ttPrefix = /hive/groups/recon/local
@@ -116,6 +122,10 @@ else ifneq ($(wildcard /usr/include/ktcommon.h),)
    ttPrefix = /usr
    kyotoTycoonIncl = -I${ttPrefix}/include -DHAVE_KYOTO_TYCOON=1 
    kyotoTycoonLib = -L${ttPrefix}/lib -Wl,-rpath,${ttPrefix}/lib -lkyototycoon -lkyotocabinet -lz -lbz2 -lpthread -lm -lstdc++
+else ifeq (${HAVE_KYOTO_TYCOON},0)
+   # Install registered with pkg-config
+   kyotoTycoonIncl = $(shell pkg-config --cflags kyototycoon) -DHAVE_KYOTO_TYCOON=1
+   kyotoTycoonLib = $(shell pkg-config --libs-only-L kyototycoon) -Wl,-rpath,$(shell pkg-config --variable=libdir kyototycoon) $(shell pkg-config --libs-only-l --static kyototycoon)
 endif
 endif
 


### PR DESCRIPTION
This works on our linuxbrew environment, but also on Ubuntu, meaning that the previous `if` block (install prefix in `/usr` could probably go as well. I didn't remove it in case I've missed something :)
