### PR TITLE
Use formatter and our own unified logger instead of root

### DIFF
--- a/src/sonLib/bioio.py
+++ b/src/sonLib/bioio.py
@@ -4,6 +4,7 @@
 #
 #Released under the MIT license, see LICENSE.txt
 
+
 import sys
 import os
 import re
@@ -37,17 +38,24 @@ DEFAULT_DISTANCE = 0.001
 
 loggingFormatter = logging.Formatter('%(asctime)s %(levelname)s %(lineno)s %(message)s')
 
-def __setDefaultLogger():
-    l = logging.getLogger()
+def __setSingleLogger():
+    """
+    Set up a logger as sonLib.bioio.logger, without interfering with later
+    calls to basicConfig on the root logger from library users who don't use
+    our logging system.
+    """
+    l = logging.getLogger(__name__)
     for handler in l.handlers: #Do not add a duplicate handler unless needed
         if handler.stream == sys.stderr:
             return l
     handler = logging.StreamHandler(sys.stderr)
+    # Make sure to apply our desired formatter.
+    handler.setFormatter(loggingFormatter)
     l.addHandler(handler)
     l.setLevel(logging.ERROR)
     return l
 
-logger = __setDefaultLogger()
+logger = __setSingleLogger()
 logLevelString = "ERROR"
 
 def redirectLoggerStreamHandlers(oldStream, newStream):


### PR DESCRIPTION
This is needed to let Toil's logging configuration system drive in Cactus, despite still relying on sonLib.bioio for other utilities.

Now only logging messages to sonLib.bioio.logger (which usually gets imported and used when people expect sonLib to drive the logging) will go through sonLib's unified logging system.

I've also hooked up the logging formatter which seemed to be unused before.