### PR TITLE
Activating Redis database in sonLib

### DIFF
--- a/C/inc/sonLibKVDatabaseConf.h
+++ b/C/inc/sonLibKVDatabaseConf.h
@@ -35,10 +35,10 @@ stKVDatabaseConf *stKVDatabaseConf_constructKyotoTycoon(const char *host, unsign
                                                         const char *databaseDir, const char* databaseName);
 
 /* 
- * Construct a new database configuration object for a Kyoto Tycoon
+ * Construct a new database configuration object for a Redis
  * database remote object.
  */
-stKVDatabaseConf *stKVDatabaseConf_constructRedis(const char *host, unsigned port);
+stKVDatabaseConf *stKVDatabaseConf_constructRedis(const char *host, unsigned port, int64_t maxBulkSetSize);
 
 /* 
  * Construct a new database configuration object for a MySql database.
@@ -102,6 +102,9 @@ int64_t stKVDatabaseConf_getMaxKTBulkSetSize(stKVDatabaseConf *conf);
 
 /* get the maximum number of records in  kyoto tycoon bulk set */
 int64_t stKVDatabaseConf_getMaxKTBulkSetNumRecords(stKVDatabaseConf *conf);
+
+/* get the maximum size in bytes of a redis bulk set */
+int64_t stKVDatabaseConf_getMaxRedisBulkSetSize(stKVDatabaseConf *conf);
 
 /* get the user for server based databases */
 const char *stKVDatabaseConf_getUser(stKVDatabaseConf *conf);

--- a/C/tests/kvDatabaseTestCommon.c
+++ b/C/tests/kvDatabaseTestCommon.c
@@ -58,6 +58,7 @@ stKVDatabaseConf *kvDatabaseTestParseOptions(int argc, char *const *argv, const 
         {"timeout", required_argument, NULL, 'i'},
         {"maxKTRecordSize", required_argument, NULL, 'r'},
         {"maxKTBulkSetSize", required_argument, NULL, 'b'},
+	{"maxRedisBulkSetSize", required_argument, NULL, 'R'},
         {"user", required_argument, NULL, 'u'},
         {"pass", required_argument, NULL, 'p'},
         {"name", required_argument, NULL, 'n'},
@@ -72,11 +73,12 @@ stKVDatabaseConf *kvDatabaseTestParseOptions(int argc, char *const *argv, const 
     int64_t optMaxKTRecordSize = (int64_t) 1U << 27;
     int64_t optMaxKTBulkSetSize = (int64_t) 1U << 27;
     int64_t optMaxKTBulkSetNumRecords = (int64_t) 1U << 27;
+    int64_t optMaxRedisBulkSetSize = (int64_t) 1U << 30;
     const char *optUser = NULL;
     const char *optPass = NULL;
     const char *optName = NULL;
     int optKey, optIndex;
-    while ((optKey = getopt_long(argc, argv, "t:d:H:P:i:r:b:u:p:h", longOptions, &optIndex)) >= 0) {
+    while ((optKey = getopt_long(argc, argv, "t:d:H:P:i:r:b:R:u:p:h", longOptions, &optIndex)) >= 0) {
         switch (optKey) {
         case 't':
             optType = parseDbType(optarg);
@@ -99,6 +101,9 @@ stKVDatabaseConf *kvDatabaseTestParseOptions(int argc, char *const *argv, const 
         case 'b':
         	optMaxKTBulkSetSize = stSafeStrToInt64(optarg);
 			break;
+	case 'R':
+                optMaxRedisBulkSetSize = stSafeStrToInt64(optarg);
+                        break;
         case 'u':
             optUser = optarg;
             break;
@@ -145,7 +150,7 @@ stKVDatabaseConf *kvDatabaseTestParseOptions(int argc, char *const *argv, const 
         conf = stKVDatabaseConf_constructMySql(optHost, 0, optUser, optPass, optDb, "cactusDbTest");
         fprintf(stderr, "running MySQL sonLibKVDatabase tests\n");
     } else if (optType == stKVDatabaseTypeRedis) {
-        conf = stKVDatabaseConf_constructRedis(optHost, optPort);
+        conf = stKVDatabaseConf_constructRedis(optHost, optPort, optMaxRedisBulkSetSize);
         fprintf(stderr, "running Redis sonLibKVDatabase tests\n");
     }
     return conf;

--- a/include.mk
+++ b/include.mk
@@ -142,7 +142,6 @@ endif
 endif
 
 # location of hiredis
-ifdef REDIS_DISABLED_FOR_NOW
 ifndef hiRedisLib
   HAVE_REDIS = $(shell pkg-config --exists hiredis; echo $$?)
   ifeq (${HAVE_REDIS},0)
@@ -155,7 +154,6 @@ ifndef hiRedisLib
       hiRedisIncl = ${incs} -DHAVE_REDIS=1
     endif
   endif
-endif
 endif
 
 dblibs = ${tokyoCabinetLib} ${kyotoTycoonLib} ${hiRedisLib} -lz -lm


### PR DESCRIPTION
This PR contains some small changes for getting Redis database back to work in sonLib. It is complementing [this PR for cactus.](https://github.com/ComparativeGenomicsToolkit/cactus/pull/338) .