### PR TITLE
Don't use void* for function pointers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 sudo: required
 dist: trusty
 language: c++
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libtokyocabinet-dev libkyototycoon-dev kyototycoon libkyotocabinet-dev; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm install ruby-2.3.3; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm use 2.3.3; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install tokyo-cabinet kyoto-cabinet kyoto-tycoon; fi
 script:
   - make && PATH=$PATH:`pwd`/bin make test
 os:

--- a/C/impl/avl.c
+++ b/C/impl/avl.c
@@ -826,7 +826,7 @@ avl_copy(const struct avl_table *org, avl_copy_func *copy,
 
 /* Frees storage allocated for |tree|.
  If |destroy != NULL|, applies it to each data item in inorder. */
-void avl_destroy2(struct avl_table *tree, avl_item_func_with_extra_arg *destroy, void *extraArg) {
+void avl_destroy2(struct avl_table *tree, avl_item_func_with_extra_arg *destroy, void (*extraArg)(void*)) {
     struct avl_node *p, *q;
 
     assert (tree != NULL);

--- a/C/impl/sonLibSortedSet.c
+++ b/C/impl/sonLibSortedSet.c
@@ -86,16 +86,15 @@ stSortedSet *stSortedSet_copyConstruct(stSortedSet *sortedSet, void (*destructEl
     return sortedSet2;
 }
 
-static void st_sortedSet_destructP(void *a, void *b, void *extraArg) {
+static void st_sortedSet_destructP(void *a, void *b, void (*extraArg)(void*)) {
     assert(b != NULL);
-    void (*destroyFn)(void *) = (void (*)(void *))extraArg;
-    destroyFn(a);
+    extraArg(a);
 }
 
 void stSortedSet_destruct(stSortedSet *sortedSet) {
     void *a = sortedSet->sortedSet->avl_param;
     if(sortedSet->destructElementFn != NULL) {
-        avl_destroy2(sortedSet->sortedSet, st_sortedSet_destructP, (void *)sortedSet->destructElementFn);
+        avl_destroy2(sortedSet->sortedSet, st_sortedSet_destructP, sortedSet->destructElementFn);
     }
     else {
         avl_destroy(sortedSet->sortedSet, NULL);

--- a/C/inc/avl.h
+++ b/C/inc/avl.h
@@ -37,7 +37,7 @@ extern "C" {
 typedef int32_t avl_comparison_func (const void *avl_a, const void *avl_b,
                                  void *avl_param);
 typedef void avl_item_func (void *avl_item, void *avl_param);
-typedef void avl_item_func_with_extra_arg (void *avl_item, void *avl_param, void *extraArg);
+typedef void avl_item_func_with_extra_arg (void *avl_item, void *avl_param, void (*extraArg)(void*));
 typedef void *avl_copy_func (void *avl_item, void *avl_param);
 
 #ifndef LIBAVL_ALLOCATOR
@@ -96,7 +96,7 @@ struct avl_table *avl_create (avl_comparison_func *, void *,
 struct avl_table *avl_copy (const struct avl_table *, avl_copy_func *,
                             avl_item_func *, struct libavl_allocator *);
 void avl_destroy (struct avl_table *, avl_item_func *);
-void avl_destroy2(struct avl_table *tree, avl_item_func_with_extra_arg *destroy, void *extraArg);
+void avl_destroy2(struct avl_table *tree, avl_item_func_with_extra_arg *destroy, void (*extraArg)(void*));
 void **avl_probe (struct avl_table *, void *);
 void *avl_insert (struct avl_table *, void *);
 void *avl_replace (struct avl_table *, void *);

--- a/allTests.py
+++ b/allTests.py
@@ -48,32 +48,6 @@ class TestCase(unittest.TestCase):
         """Run most of the sonLib CuTests, fail if any of them fail."""
         system("sonLibTests %s" % getLogLevelString())
 
-    @needsProgram('ktserver')
-    def testSonLibKTTests(self):
-        """Run the sonLib KyotoTycoon interface tests."""
-        ktserver = Popen(["ktserver", "-le"])
-        # Give the server ample time to start up
-        time.sleep(3)
-        try:
-            check_call(["sonLib_kvDatabaseTest", "-t", "kyototycoon", "--port", "1978"])
-        finally:
-            ktserver.kill()
-
-    @needsPackage('hiredis')
-    def testSonLibRedisTests(self):
-        """Run the sonLib Redis interface tests."""
-        redis = Popen(["redis-server"])
-        # Give the server ample time to start up
-        time.sleep(3)
-        try:
-            check_call(["sonLib_kvDatabaseTest", "-t", "redis", "--port", "6379"])
-        finally:
-            redis.kill()
-
-    def testSonLibKVTokyoCabinet(self):
-        """Run the sonLib TokyoCabinet interface tests."""
-        system("sonLib_kvDatabaseTest --type=tokyocabinet")
-
 def allSuites():
     bioioSuite = unittest.makeSuite(bioioTest.TestCase, 'test')
     cigarsSuite = unittest.makeSuite(cigarsTest.TestCase, 'test')


### PR DESCRIPTION
[This commit](https://github.com/ComparativeGenomicsToolkit/sonLib/commit/87bbd14025e43370a24cdb3174c0e7fda1784fff) broke the build (and hal's ci) because `-Werror --pedantic` doesn't like using void* for function pointers:
```
impl/sonLibSortedSet.c:91:33: error: ISO C forbids conversion of object pointer to function pointer type [-Werror=pedantic]

     void (*destroyFn)(void *) = (void (*)(void *))extraArg;
```
This best I can tell this is a legitimate complaint in that the standard doesn't cover it, but you'd have to try pretty hard to find an architecture in practice where function and object pointers have different sizes.  

This PR uses `void(*)(void*)` instead of `void*` to appease the compiler.  

