### PR TITLE
Use _DEFAULT_SOURCE

### DIFF
--- a/C/impl/commonC.c
+++ b/C/impl/commonC.c
@@ -3,7 +3,7 @@
  *
  * Released under the MIT license, see LICENSE.txt
  */
-#define _BSD_SOURCE   // for mkstemp
+#define _DEFAULT_SOURCE   // for mkstemp
 #include "fastCMaths.h"
 #include "commonC.h"
 #include "hashTableC.h"


### PR DESCRIPTION
Listen to [Cactus CI when it tells us to use _DEFAULT_SOURCE](https://travis-ci.org/github/ComparativeGenomicsToolkit/cactus/jobs/767071193):
```
cc -Iinc -Iimpl -I../externalTools/quicktree_1.1/include/ -I ../externalTools/cutest -fPIC -std=c99 -Wall -O0 -Werror --pedantic -g -fno-inline -UNDEBUG -Wno-error=unused-result -c impl/*.c
In file included from /usr/include/x86_64-linux-gnu/bits/libc-header-start.h:33:0,
                 from /usr/include/math.h:27,
                 from inc/fastCMaths.h:20,
                 from impl/commonC.c:7:
/usr/include/features.h:184:3: error: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Werror=cpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^~~~~~~
cc1: all warnings being treated as errors
```