### PR TITLE
Make sure chars are treated as signed by default

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -20,6 +20,13 @@ CXXFLAGS += -fPIC
 CPPFLAGS += -Iinc -Iimpl
 
 ##
+# On ARM/clang (but not on Mac?) char is unsigned by default
+# This breaks file parsing in sonLib which compares char to EOF (-1)
+# https://stackoverflow.com/questions/19555248/clang-make-char-signed-by-default-on-arm
+CFLAGS += -fsigned-char
+CPPFLAGS += -fsigned-char
+
+##
 # For GCC, the C++ 11 aplication binary interface must match the version
 # that HDF5 uses.  Change the ABI version can address errors about undefined functions that vary
 # by string type, such as 


### PR DESCRIPTION
Fasta parsing in sonlib does stuff like
```
char j = getc(file)....
if (j != EOF) ...
```

When compiling with clang on Graviton, this leads to warnings like
```
impl/bioioC.c:165:33: warning: result of comparison of constant -1 with expression of type 'char' is always true [-Wtautological-constant-out-of-range-compare]
    while((j = getc(fastaFile)) != EOF) { //initial terminating characters
```

Because apparently in this environment `char` is actually [unsigned by default](https://stackoverflow.com/questions/19555248/clang-make-char-signed-by-default-on-arm).  

This breaks everything, but is easily fixed with a compiler flag (which is redundant by seemingly harmless on other systems)

